### PR TITLE
feat: added inline options for config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ aws_profile: the aws profile to use. Should have the necessary IAM permissions t
 
 ssh_instance_tag: tag used to identify the (jump) instance that will be used to set up the SSH session. If multiple instances are identified, a random one will be chosen. You can overwrite this variable by passing --tag to the session commands.
 ```
+Or you can use the following options:
+```
+Usage: aws_ssh_tunnel.py config [OPTIONS]
+
+  Set AWS configuration.
+
+Options:
+  -t, --tag TEXT  tag (format: KEY=VALUE) of the (jump) instance that will be
+                  used to set up the SSH (tunneling) session. If tunneling to
+                  RDS or other services which only allow internal vpc traffic,
+                  pass the tag of a dedicated jump instance. Omit to use the
+                  tag environment variable in the local configuration file.
+                  [default: (ssh_instance_tag environment variable in aws-ssh-
+                  tunnel.cfg)]
+  --region TEXT   AWS region to use for tunneling session.
+  --profile TEXT  AWS profile to assume for tunneling session.
+  --help          Show this message and exit.
+```
 *port forwarding*
 ```
 Usage: aws-ssh-tunnel start-forwarding-session [OPTIONS]

--- a/aws_ssh_tunnel.py
+++ b/aws_ssh_tunnel.py
@@ -183,7 +183,18 @@ def initialize_environment(tag, remote_host=None, port=None):
 
 
 @main.command()
-def config():
+@common_options
+@click.option(
+    "--region",
+    type=str,
+    help="AWS region to use for tunneling session."
+)
+@click.option(
+    "--profile",
+    type=str,
+    help="AWS profile to assume for tunneling session."
+)
+def config(region, profile, tag):
     """
     Set AWS configuration.
     """
@@ -193,18 +204,28 @@ def config():
     if len(cfg) > 0 and "aws_environment" in cfg:
         aws_config = dict(cfg["aws_environment"])
 
-    aws_region = click.prompt(
-        "AWS region to use for tunneling session",
-        default=aws_config.get("aws_region"),
-    )
-    aws_profile = click.prompt(
-        "AWS profile to assume for tunneling session",
-        default=aws_config.get("aws_profile"),
-    )
-    tag = click.prompt(
-        "Tag used to identify the (jump) instance that will be used to set up the SSH session",
-        default=aws_config.get("ssh_instance_tag"),
-    )
+    if not region:
+        aws_region = click.prompt(
+            "AWS region to use for tunneling session",
+            default=aws_config.get("aws_region"),
+        )
+    else:
+        aws_region = region
+
+    if not profile:
+        aws_profile = click.prompt(
+            "AWS profile to assume for tunneling session",
+            default=aws_config.get("aws_profile"),
+        )
+    else:
+        aws_profile = profile
+
+    if not tag:
+        tag = click.prompt(
+            "Tag used to identify the (jump) instance that will be used to set up the SSH session",
+            default=aws_config.get("ssh_instance_tag"),
+        )
+
     aws_config = {
         **aws_config,
         **{

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="aws-ssh-tunnel",
-    version="2.1.0",
+    version="2.2.0",
     author="Daniel Molenaars",
     author_email="danielmolenaars@binx.io",
     description="CLI for port forwarding sessions with private AWS RDS and EC2 instances.",


### PR DESCRIPTION
One of our customers requested to add inline options support for the config command.

```
Usage: aws_ssh_tunnel config [OPTIONS]

  Set AWS configuration.

Options:
  -t, --tag TEXT  tag (format: KEY=VALUE) of the (jump) instance that will be
                  used to set up the SSH (tunneling) session. If tunneling to
                  RDS or other services which only allow internal vpc traffic,
                  pass the tag of a dedicated jump instance. Omit to use the
                  tag environment variable in the local configuration file.
                  [default: (ssh_instance_tag environment variable in aws-ssh-
                  tunnel.cfg)]
  --region TEXT   AWS region to use for tunneling session.
  --profile TEXT  AWS profile to assume for tunneling session.
  --help          Show this message and exit.
```