### PR TITLE
change configuration setup and add options for aws_profile and aws_re…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ env.bak/
 venv.bak/
 *.cfg
 .idea/
+.vscode/

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup
 from pathlib import Path
+
+from setuptools import setup
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()


### PR DESCRIPTION
- Added click option for profile and region
- If args are provided for tag, profile or region it overwrites the defaults in config file
- Added type hints, to all functions (easier to see if all the optional passing works)
- Ran isort and black for formatting, they are not part of the dev dependencies (I would recommend adding this). 

I tested it locally, everything seems to work. There are no unittest so I want to test it a bit more thorough tomorrow (or I can add unittests, but this would require some more changes in for example setup.py and deps). 

Anyways, if I need to change anything let me know. 